### PR TITLE
Add BigFrontEnd.dev to Exercises & Challenges

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ Resource types:
 - [Create a Game: Breakout](https://billmill.org/static/canvastutorial/index.html)
 - [Easybank Landing Page](https://www.frontendmentor.io/challenges/easybank-landing-page-WaUhkoDN)
 - [IP Adress Tracker](https://www.frontendmentor.io/challenges/ip-address-tracker-I8-0yYAH0)
+- [BigFrontEnd](https://bigfrontend.dev/) 🎮 🎁 💰
 
 ### Web Animations
 


### PR DESCRIPTION
## Summary
- Adds [BigFrontEnd.dev](https://bigfrontend.dev/) to the existing "Exercises & Challenges" section
- Uses correct markdown formatting (`- [Name](url) 🎮 🎁 💰`)
- Tagged as both free and paid (`🎁 💰`) to reflect its freemium model
- Placed at the end of the section per contribution guidelines

This is a corrected version of PR #48, which had broken markdown syntax, missing emoji spacing, and created an unnecessary new section.

## Test plan
- [ ] Verify the link renders correctly as a clickable list item
- [ ] Confirm https://bigfrontend.dev/ resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)